### PR TITLE
Add automatic setup for Ubuntu 24.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /server-scripts
 /.vscode
 /debug
+/tools

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
-TAMARIN_RELEASE ?= tamarin-prover
+TOOLS_DIR := $(CURDIR)/tools
+TAMARIN_RELEASE := $(TOOLS_DIR)/tamarin-prover
 N_THREADS ?= 10
 PORT ?= 3001
+
+# Tamarin will look for maude and inherit it
+export PATH := $(PATH):$(TOOLS_DIR)
+
+# Linux setup (Tested on Ubuntu 24.04)
+.PHONY: setup
+setup:
+	mkdir -p tools
+	cd tools && \
+		curl -OL https://github.com/tamarin-prover/tamarin-prover/releases/download/1.10.0/tamarin-prover-1.10.0-linux64-ubuntu.tar.gz && \
+		tar -xvzf tamarin-prover-1.10.0-linux64-ubuntu.tar.gz && \
+		curl -OL https://github.com/maude-lang/Maude/releases/download/Maude3.5/Maude-3.5-linux-x86_64.zip && \
+		unzip -o Maude-3.5-linux-x86_64.zip
 
 .PHONY: well-formed
 well-formed:


### PR DESCRIPTION
Add make setup for Ubuntu 24.04 and changes paths to support that. Requires curl, unzip. If we wanted, we could also detect if it's Mac or Linux and setup accordingly, but I don't think it's worth it.